### PR TITLE
Rename item to key and make private

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ To know more about the contents of the tree, you can print it to stdout:
 
 ```
 bst.print_tree()  # prints an ASCII representation of the whole tree
+```
 
 #### Traversals 
 

--- a/src/rbtree.py
+++ b/src/rbtree.py
@@ -26,7 +26,7 @@ class Node():
         return self.id == other.id
 
     def __repr__(self: T) -> str:
-        return "ID: " + str(self.id) + " Value: " + str(self._key)
+        return "Key: " + str(self._key) + " Value: " + str(self.value)
 
     def get_color(self: T) -> str:
         return "black" if self.color == 0 else "red"

--- a/src/rbtree.py
+++ b/src/rbtree.py
@@ -12,10 +12,10 @@ T = TypeVar('T', bound='Node')
 class Node():
     next_id = 0
 
-    def __init__(self: T, item: int) -> None:
+    def __init__(self: T, key: int) -> None:
         self.id = Node.next_id
         Node.next_id += 1
-        self.item = item
+        self._key = key
         self.parent = None
         self.left = None
         self.right = None
@@ -26,7 +26,7 @@ class Node():
         return self.id == other.id
 
     def __repr__(self: T) -> str:
-        return "ID: " + str(self.id) + " Value: " + str(self.item)
+        return "ID: " + str(self.id) + " Value: " + str(self._key)
 
     def get_color(self: T) -> str:
         return "black" if self.color == 0 else "red"
@@ -40,7 +40,7 @@ class Node():
             raise Exception("Unknown color")
 
     def get_key(self: T) -> int:
-        return self.item
+        return self._key
 
     def is_red(self: T) -> bool:
         return self.color == 1
@@ -151,10 +151,10 @@ class RedBlackTree():
 
     # Search the tree
     def search_tree_helper(self: T, node: Node, key: int) -> Node:
-        if node.is_null() or key == node.item:
+        if node.is_null() or key == node.get_key():
             return node
 
-        if key < node.item:
+        if key < node.get_key():
             return self.search_tree_helper(node.left, key)
         return self.search_tree_helper(node.right, key)
 
@@ -222,10 +222,10 @@ class RedBlackTree():
     def delete_node_helper(self: T, node: Node, key: int) -> None:
         z = self.TNULL
         while not node.is_null():
-            if node.item == key:
+            if node.get_key() == key:
                 z = node
 
-            if node.item <= key:
+            if node.get_key() <= key:
                 node = node.right
             else:
                 node = node.left
@@ -265,38 +265,38 @@ class RedBlackTree():
         self.size -= 1
 
     # Balance the tree after insertion
-    def fix_insert(self: T, k: Node) -> None:
-        while k.parent.is_red():
-            if k.parent == k.parent.parent.right:
-                u = k.parent.parent.left
+    def fix_insert(self: T, node: Node) -> None:
+        while node.parent.is_red():
+            if node.parent == node.parent.parent.right:
+                u = node.parent.parent.left
                 if u.is_red():
                     u.set_color("black")
-                    k.parent.set_color("black")
-                    k.parent.parent.set_color("red")
-                    k = k.parent.parent
+                    node.parent.set_color("black")
+                    node.parent.parent.set_color("red")
+                    node = node.parent.parent
                 else:
-                    if k == k.parent.left:
-                        k = k.parent
-                        self.right_rotate(k)
-                    k.parent.set_color("black")
-                    k.parent.parent.set_color("red")
-                    self.left_rotate(k.parent.parent)
+                    if node == node.parent.left:
+                        node = node.parent
+                        self.right_rotate(node)
+                    node.parent.set_color("black")
+                    node.parent.parent.set_color("red")
+                    self.left_rotate(node.parent.parent)
             else:
-                u = k.parent.parent.right
+                u = node.parent.parent.right
 
                 if u.is_red():
                     u.set_color("black")
-                    k.parent.set_color("black")
-                    k.parent.parent.set_color("red")
-                    k = k.parent.parent
+                    node.parent.set_color("black")
+                    node.parent.parent.set_color("red")
+                    node = node.parent.parent
                 else:
-                    if k == k.parent.right:
-                        k = k.parent
-                        self.left_rotate(k)
-                    k.parent.set_color("black")
-                    k.parent.parent.set_color("red")
-                    self.right_rotate(k.parent.parent)
-            if k == self.root:
+                    if node == node.parent.right:
+                        node = node.parent
+                        self.left_rotate(node)
+                    node.parent.set_color("black")
+                    node.parent.parent.set_color("red")
+                    self.right_rotate(node.parent.parent)
+            if node == self.root:
                 break
         self.root.set_color("black")
 
@@ -312,12 +312,12 @@ class RedBlackTree():
                 indent += "|    "
 
             s_color = "RED" if node.is_red() else "BLACK"
-            print(str(node.item) + "(" + s_color + ")")
+            print(str(node.get_key()) + "(" + s_color + ")")
             self.__print_helper(node.left, indent, False)
             self.__print_helper(node.right, indent, True)
 
-    def search(self: T, k: int) -> Node:
-        return self.search_tree_helper(self.root, k)
+    def search(self: T, key: int) -> Node:
+        return self.search_tree_helper(self.root, key)
 
     def minimum(self: T, node: Node = None) -> Node:
         if node is None:
@@ -392,8 +392,6 @@ class RedBlackTree():
 
     def insert(self: T, key: int) -> None:
         node = Node(key)
-        node.parent = None
-        node.item = key
         node.left = self.TNULL
         node.right = self.TNULL
         node.set_color("red")
@@ -403,7 +401,7 @@ class RedBlackTree():
 
         while not x.is_null():
             y = x
-            if node.item < x.item:
+            if node.get_key() < x.get_key():
                 x = x.left
             else:
                 x = x.right
@@ -411,7 +409,7 @@ class RedBlackTree():
         node.parent = y
         if y is None:
             self.root = node
-        elif node.item < y.item:
+        elif node.get_key() < y.get_key():
             y.left = node
         else:
             y.right = node
@@ -427,8 +425,8 @@ class RedBlackTree():
 
         self.fix_insert(node)
 
-    def delete(self: T, item: int) -> None:
-        self.delete_node_helper(self.root, item)
+    def delete(self: T, key: int) -> None:
+        self.delete_node_helper(self.root, key)
 
     def print_tree(self: T) -> None:
         self.__print_helper(self.root, "", True)

--- a/tests/test_rbtree.py
+++ b/tests/test_rbtree.py
@@ -12,9 +12,9 @@ def check_node_valid(bst: RedBlackTree, node: Node) -> None:
         assert node.right.is_black()
 
     if not node.left.is_null() and node.left is not None:
-        assert node.item >= node.left.item
+        assert node.get_key() >= node.left.get_key()
     if not node.right.is_null() and node.right is not None:
-        assert node.item <= node.right.item
+        assert node.get_key() <= node.right.get_key()
 
 
 def check_valid_recur(bst: RedBlackTree, node: Node) -> int:
@@ -52,13 +52,13 @@ def check_valid(bst: RedBlackTree) -> None:
 def test_insert() -> None:
     bst = RedBlackTree()
     bst.insert(55)
-    assert bst.search(55).item == 55
+    assert bst.search(55).get_key() == 55
     bst.insert(40)
-    assert bst.search(40).item == 40
+    assert bst.search(40).get_key() == 40
     bst.insert(58)
-    assert bst.search(58).item == 58
+    assert bst.search(58).get_key() == 58
     bst.insert(42)
-    assert bst.search(42).item == 42
+    assert bst.search(42).get_key() == 42
 
     bst.insert(42)
     bst.insert(42)
@@ -89,13 +89,13 @@ def test_search() -> None:
     bst = RedBlackTree()
     assert bst.search(60).is_null()
     bst.insert(30)
-    assert bst.search(30).item == 30
+    assert bst.search(30).get_key() == 30
 
 
 def test_delete() -> None:
     bst = RedBlackTree()
     bst.insert(78)
-    assert bst.search(78).item == 78
+    assert bst.search(78).get_key() == 78
     bst.delete(78)
     assert bst.search(78).is_null()
 
@@ -120,7 +120,7 @@ def test_delete() -> None:
     assert bst.size == 10
     bst.delete(42)
     assert bst.size == 9
-    assert bst.search(42).item == 42
+    assert bst.search(42).get_key() == 42
     bst.delete(42)
     assert bst.search(42).is_null()
     assert bst.size == 8
@@ -168,7 +168,7 @@ def test_get_root() -> None:
     bst = RedBlackTree()
     assert bst.get_root().is_null()
     bst.insert(3)
-    assert bst.get_root().item == 3
+    assert bst.get_root().get_key() == 3
 
 
 def test_accessors() -> None:
@@ -181,17 +181,17 @@ def test_accessors() -> None:
     bst.insert(58)
     bst.insert(42)
 
-    assert bst.maximum().item == 58
-    assert bst.minimum().item == 40
-    assert bst.successor(bst.search(42)).item == 55
-    assert bst.successor(bst.search(40)).item == 42
-    assert bst.successor(bst.search(55)).item == 58
-    assert bst.predecessor(bst.search(42)).item == 40
-    assert bst.predecessor(bst.search(55)).item == 42
-    assert bst.predecessor(bst.search(58)).item == 55
+    assert bst.maximum().get_key() == 58
+    assert bst.minimum().get_key() == 40
+    assert bst.successor(bst.search(42)).get_key() == 55
+    assert bst.successor(bst.search(40)).get_key() == 42
+    assert bst.successor(bst.search(55)).get_key() == 58
+    assert bst.predecessor(bst.search(42)).get_key() == 40
+    assert bst.predecessor(bst.search(55)).get_key() == 42
+    assert bst.predecessor(bst.search(58)).get_key() == 55
 
     bst.insert(57)
-    assert bst.predecessor(bst.search(57)).item == 55
+    assert bst.predecessor(bst.search(57)).get_key() == 55
 
 
 def test_preorder() -> None:


### PR DESCRIPTION
I created the Node.get_key() method in an earlier PR. For consistency, I renamed Node.item to Node._key, making it private. This way, users would not be able to change the key of a Node object after it has been created.